### PR TITLE
Small enhancement for dynamically added forms

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -213,7 +213,11 @@
 
   // VALIDATOR DATA-API
   // ==================
-
+  $(document).on('input.bs.validator change.bs.validator focusout.bs.validator', 'form[data-toggle="validator"]', function (e) {
+    var $form = $(this)
+    $form.validator($form.data())
+  })
+    
   $(window).on('load', function () {
     $('form[data-toggle="validator"]').each(function () {
       var $form = $(this)


### PR DESCRIPTION
In case forms are added after the validator plugin is loaded, the `$(window).load()` will miss those. To pick up those I added a `$(document).on()` event handler installing the validator the first time a form is used. There might be a small performance hit of doing that check with each form, but this is very very unlikely it makes any difference in your app.
