### PR TITLE
Allow HTML in custom error messages

### DIFF
--- a/js/tests/unit/validator.js
+++ b/js/tests/unit/validator.js
@@ -228,4 +228,28 @@ $(function () {
     $('#required2').prop('checked', false).trigger('change')
     ok(!$btn.attr('disabled'), 'submit button still enabled')
   })
+
+  test('should attach HTMLElement error message, rather than text', function() {
+    stop()
+    var form = '<form>'
+      + '<div class="form-group">'
+      +   '<input type="text" data-minlength="6" value="pizza">'
+      +   '<div id="inputErrors" class="help-block with-errors"></div>'
+      + '</div>'
+      + '</form>';
+    form = $(form)
+      .appendTo('#qunit-fixture')
+
+    var error = $('<div/>').append($('<span/>').text('error'))[0]
+    $(form).find('input')
+      .data('minlength-error', error)
+
+    $(form)
+      .on('invalid.bs.validator', function (e) {
+        equal($(this).find('.help-block.with-errors li').html(), error.outerHTML,
+            'Custom error element was not appended')
+        start()
+      })
+      .validator('validate')
+  })
 })

--- a/js/validator.js
+++ b/js/validator.js
@@ -137,7 +137,12 @@
 
       errors = $('<ul/>')
         .addClass('list-unstyled')
-        .append($.map(errors, function (error) { return $('<li/>').text(error) }))
+        .append($.map(errors, function (error) {
+            return error instanceof HTMLElement
+              ? $('<li/>').append(error)
+              : $('<li/>').text(error)
+            }))
+
 
       $block.data('bs.originalContent') === undefined && $block.data('bs.originalContent', $block.html())
       $block.empty().append(errors)


### PR DESCRIPTION
I'd like to embed a link in an error message.  
In this change, if the error object in the element's data derives from HTMLElement, it's appended to the <li>.  Otherwise, it's set as the <li>'s text.  
