### PR TITLE
hasErrors call is now public.

### DIFF
--- a/js/tests/unit/validator.js
+++ b/js/tests/unit/validator.js
@@ -326,4 +326,36 @@ $(function () {
     ok(form.find('.help-block').html() === 'original content', 'help block content restored')
     ok(!form.find('button').is('.disabled'), 're-enabled submit button')
   })
+
+  test('should return true  on hasErrors call', function () {
+    var form = '<form>'
+      + '<div class="form-group">'
+      +   '<input type="text" data-error="error message" required>'
+      +   '<div class="help-block with-errors">original content</div>'
+      + '</div>'
+      + '<button type="submit">Submit</button>'
+      + '</form>'
+
+    form = $(form)
+      .appendTo('#qunit-fixture')
+      .validator('validate')
+
+    ok(form.validator('hasErrors'), 'there are errors')
+  })
+
+  test('should return false on hasErrors call', function () {
+    var form = '<form>'
+      + '<div class="form-group">'
+      +   '<input type="text" data-error="error message">'
+      +   '<div class="help-block with-errors">original content</div>'
+      + '</div>'
+      + '<button type="submit">Submit</button>'
+      + '</form>'
+
+    form = $(form)
+      .appendTo('#qunit-fixture')
+      .validator('validate')
+
+    ok(!form.validator('hasErrors'), 'there are not errors')
+  })
 })

--- a/js/validator.js
+++ b/js/validator.js
@@ -248,6 +248,10 @@
 
 
   function Plugin(option) {
+    var data    = $(this).data('bs.validator')
+    if (data && typeof option == 'string' && option == 'hasErrors') return data[option]()
+
+
     return this.each(function () {
       var $this   = $(this)
       var options = $.extend({}, Validator.DEFAULTS, $this.data(), typeof option == 'object' && option)


### PR DESCRIPTION
Hello @1000hz, I change the plugin a bit in order to make public the function hasErrors. 
Now its possible to call `.validator('hasErrors')` to check if the form is ready to submit or not.

Let me know if its acceptable and I can update the documentation if its needed. 
Thanks a lot!
