### PR TITLE
Adds support for custom validator functions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -253,6 +253,9 @@ errors: {
     <h4>$().validator('destroy')</h4>
     <p>Destroys form validator and cleans up data left behind.</p>
 
+    <h4>$().validator('register', name, func)</h4>
+    <p>Registers a custom validation function. The validation function will be passed a single parameter set to a jQuery object. The function should return true or false.</p>
+
     <h3 id="validator-events">Events</h3>
     <p>All events are fired on the form element and provide a reference to the form field to which the event pertains via <code>event.relatedTarget</code>.</p>
 

--- a/js/tests/unit/validator.js
+++ b/js/tests/unit/validator.js
@@ -389,4 +389,27 @@ $(function () {
     ok(form.find('.help-block').html() === 'original content', 'help block content restored')
     ok(!form.find('button').is('.disabled'), 're-enabled submit button')
   })
+
+  test("should register custom validators to the custom options object", function () {
+    stop()
+    var form = '<form data-form="true">'
+      + '<input type="text" data-foo="bar">'
+      + '</form>'
+
+    form = $(form)
+      .on('invalid.bs.validator', function (e) {
+        ok(false)
+      })
+      .on('valid.bs.validator', function (e) {
+        ok(true)
+      })
+
+    form.validator('register', 'foo', function(el){
+      return el.attr('data-foo') === 'bar'
+    })
+
+    start()
+    form.validator('validate')
+
+  })
 })


### PR DESCRIPTION
This commit adds the ability to wire up new validator functions.
Each function gets added to a `custom` property on the `options`
object.

Registering a function looks like:

```javascript
$form.validator('register', 'functionName', function(el) {
  return 1 === 0
});
```