### PR TITLE
Apply validator even if matching data attribute is empty or 0

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -140,7 +140,7 @@
     }
 
     $.each(Validator.VALIDATORS, $.proxy(function (key, validator) {
-      if (($el.data(key) || key == 'native') && !validator.call(this, $el)) {
+      if ((typeof $el.data(key) !== 'undefined' || key == 'native') && !validator.call(this, $el)) {
         var error = getErrorMessage(key)
         !~errors.indexOf(error) && errors.push(error)
       }


### PR DESCRIPTION
Html:

    <input type="text" data-pizza="0" />

Js:

    $form.validator({
        custom: {
            pizza: function($el) {
                return true;
            }
        },
        errors: {
            pizza: '[Pizza] Error'
        }
    });

This validator wont be applied because js treats 0 as falsy.