### PR TITLE
Update validator.js - android native browser fix

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -77,7 +77,7 @@
   }
 
   Validator.VALIDATORS = {
-    native: function ($el) {
+    'native': function ($el) {
       var el = $el[0]
       return el.checkValidity ? el.checkValidity() : true
     },


### PR DESCRIPTION
Android native browser in version 2.3.6 chokes on the bare keyword 'native' - putting that in quotes makes him happy