### PR TITLE
Automatically add helpblock & feedback if missing

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -71,8 +71,8 @@
       minlength: 'Not long enough'
     },
     feedback: {
-      success: 'glyphicon-ok',
-      error: 'glyphicon-warning-sign'
+      success: 'glyphicon glyphicon-ok',
+      error: 'glyphicon glyphicon-warning-sign'
     }
   }
 
@@ -179,6 +179,9 @@
       var errors = $el.data('bs.validator.errors')
 
       if (!errors.length) return
+
+      if (!$feedback.length && this.options.feedback.error) $feedback = $('<span class="form-control-feedback"/>').insertAfter($el);
+      if (!$block.length) $block = $('<div class="help-block with-errors"/>').insertAfter($feedback.length ? $feedback : $el);
 
       errors = $('<ul/>')
         .addClass('list-unstyled')


### PR DESCRIPTION
It's kind of frustrating that you have to add these placeholders, this should suit most people. If you need a more specific placement for the helpblock or feedback, just add one manually and it will use that one instead.

One thing that's a bit of a 'breaking' change is that it will always show the feedback icons now, unless you set in the options `feedback.success` and `feedback.error` to falsey.