### PR TITLE
enable error hint overwriting from browser

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -133,10 +133,20 @@
     $el.data('bs.validator.deferred', deferred)
 
     function getErrorMessage(key) {
+    if (key == 'native'){
+        for (var i in $el[0].validity){
+          if ($el[0].validity[i]){
+            if (options.errors.hasOwnProperty(key)){
+              key = i;
+            }
+            break;
+          }
+        }
+      }
       return $el.data(key + '-error')
         || $el.data('error')
-        || key == 'native' && $el[0].validationMessage
         || options.errors[key]
+        || key == 'native' && $el[0].validationMessage
     }
 
     $.each(Validator.VALIDATORS, $.proxy(function (key, validator) {


### PR DESCRIPTION
I was in one situation that client asked me to change default error hint and I had to do some monkey patch. Afterwards, I think this might be handy for others. Adding these lines won't affect people using previous releases. Hope this helps.