### PR TITLE
Add a file extension check on the validator.

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -69,7 +69,8 @@
     custom: {},
     errors: {
       match: 'Does not match',
-      minlength: 'Not long enough'
+      minlength: 'Not long enough',
+      ext: 'This file type is not supported.'
     },
     feedback: {
       success: 'glyphicon-ok',
@@ -89,7 +90,12 @@
     'minlength': function ($el) {
       var minlength = $el.data('minlength')
       return !$el.val() || $el.val().length >= minlength
-    }
+    },
+    'ext': function ($el) {
+        var validExts = $el.data('ext') == 'accept' ? $el.prop('accept') : $el.data('ext');
+        var ext = $el.val().split('.').pop().toLowerCase();
+        return !$el.val() || $.inArray(ext, validExts.toLowerCase().replace(/[\. ]/g,'').split(',')) != -1;
+	}
   }
 
   Validator.prototype.validateInput = function (e) {


### PR DESCRIPTION
Considering the input:
```html
<input id="file-button" type="file" accept=".png, .bmp" data-ext="accept">
```
Then, if you select a file with a wrong extension (it's possible even if you fill the `accept` attribute), this will display the error: `This file type is not supported.`

You can also set your own valid extensions with: `data-ext=".png, .bmp"`, even if it doesn't really make sense to set a different value from `accept` attribute.