### PR TITLE
Add support for pattern custom messages

### DIFF
--- a/js/tests/unit/validator.js
+++ b/js/tests/unit/validator.js
@@ -126,6 +126,23 @@ $(function () {
       .validator('validate')
   })
 
+  QUnit.test('should allow pattern specific error message', function (assert) {
+    var done = assert.async()
+    var form = '<form>'
+      + '<div class="form-group">'
+      +   '<input type="text" value="pizza" data-pattern-error="pattern error" pattern="^[0-9]*$">'
+      +   '<div class="help-block with-errors">Pattern</div>'
+      + '</div>'
+      + '</form>'
+
+    $(form)
+      .on('invalid.bs.validator', function (e) {
+        assert.ok($(this).find('.help-block.with-errors').text() == 'pattern error', 'specific error message was set')
+        done()
+      })
+      .validator('validate')
+  })
+
   QUnit.test('should give precedence to specific error message over generic error message', function (assert) {
     var done = assert.async()
     var form = '<form>'

--- a/js/validator.js
+++ b/js/validator.js
@@ -133,9 +133,18 @@
     $el.data('bs.validator.deferred') && $el.data('bs.validator.deferred').reject()
     $el.data('bs.validator.deferred', deferred)
 
+    function getNativeKey(el) {
+      var key = '';
+      if(el.validity.patternMismatch) key = 'pattern-';
+      if(el.validity.tooShort) key = 'minlength-';
+      if(el.validity.tooLong) key = 'maxlength-';
+
+      return key;
+    }
+
     function getErrorMessage(key) {
       return $el.data(key + '-error')
-        || $el.data('error')
+        || $el.data(getNativeKey($el[0]) + 'error')
         || key == 'native' && $el[0].validationMessage
         || options.errors[key]
     }


### PR DESCRIPTION
I have added support for custom error messages when using the pattern attribute on forms.

Just using the `data-error="blah"` attribute doesn't work when there are more than one validation rules being applied to an input. E.g:

`<input type="text" pattern="^[0-9]*$" data-error="Some message" required name="afield" />`
*(In this example a number input would be a better choice, but used this example for the simplicity of the regex)*

In this instance you would want the message to be different depending on the criteria that is causing the error.

This change adds the ability to use `data-pattern-error="The message"` and have this applied only for failed patterns.

I also added in the ability to set messages for native `maxlength` and `minlength` failures using the existing `data-[max | min]length-error` attributes.