### PR TITLE
IE 9 onload fix

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -315,7 +315,7 @@
   // VALIDATOR DATA-API
   // ==================
 
-  $(window).on('load', function () {
+  $(function () {
     $('form[data-toggle="validator"]').each(function () {
       var $form = $(this)
       Plugin.call($form, $form.data())


### PR DESCRIPTION
on load was not being called on IE 9, verified this because had to support IE 9 with shims and was not behaving correctly, sometimes didn't init the validator