### PR TITLE
Remove deprecated bower option: version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "bootstrap-validator",
-  "version": "0.10.1",
   "homepage": "https://github.com/1000hz/bootstrap-validator",
   "authors": [
     "Cina Saffary <itscina@gmail.com>"


### PR DESCRIPTION
`version` option for `bower.json` it;s deprecated and it's already ignored by bower, as you can read in [bower.json specification](https://github.com/bower/spec/blob/master/json.md#version).