### PR TITLE
Modifies focusError method to focus on first error within form element

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -206,7 +206,7 @@
   Validator.prototype.focusError = function () {
     if (!this.options.focus) return
 
-    var $input = $(".has-error:first :input")
+    var $input = this.$element.find(".has-error:first :input")
     if ($input.length === 0) return
 
     $(document.body).animate({scrollTop: $input.offset().top - Validator.FOCUS_OFFSET}, 250)


### PR DESCRIPTION
When .has-error was used outside the validated form, the focusError method was trying to focus on that element (outside the form). This change focuses in the first error within the form that is currently being validated.