### PR TITLE
Dinamic custom message

### DIFF
--- a/dist/validator.js
+++ b/dist/validator.js
@@ -149,10 +149,12 @@
     }
 
     $.each(Validator.VALIDATORS, $.proxy(function (key, validator) {
+      var response=validator.call(this, $el)
+      var has_error=response instanceof Object ? response.valid : response
       if ((getValue($el) || $el.attr('required')) &&
           ($el.data(key) || key == 'native') &&
-          !validator.call(this, $el)) {
-        var error = getErrorMessage(key)
+          !has_error) {
+        var error = response instanceof Object ? response.message : getErrorMessage(key)
         !~errors.indexOf(error) && errors.push(error)
       }
     }, this))

--- a/dist/validator.js
+++ b/dist/validator.js
@@ -298,6 +298,33 @@
     return this
   }
 
+  Validator.prototype.reset = function () {
+    this.$element
+      .find('.form-control-feedback')
+        .removeClass([this.options.feedback.error, this.options.feedback.success].join(' '))
+
+    this.$element.find(':input')
+      .removeData(['bs.validator.errors', 'bs.validator.deferred', 'bs.validator.previous'])
+      .each(function () {
+        var $this = $(this)
+        var timeout = $this.data('bs.validator.timeout')
+        window.clearTimeout(timeout) && $this.removeData('bs.validator.timeout')
+      })
+
+    this.$element.find('.help-block.with-errors').each(function () {
+      var $this = $(this)
+      var originalContent = $this.data('bs.validator.originalContent')
+
+      $this
+        .removeData('bs.validator.originalContent')
+        .html(originalContent)
+    })
+
+    this.$element.find('.has-error, .has-danger').removeClass('has-error has-danger')
+
+    return this
+  }
+
   // VALIDATOR PLUGIN DEFINITION
   // ===========================
 


### PR DESCRIPTION
- Reset: Let you clean all done validations.

- Dinamic validation: Optional messages for custom validators.
This always check for 2 answers: a single validation (boolean response), or an object with the validation and the message you want to show.

Example code: Custom validator to make login with username or email. Default value is Email.
```javascript
var regex_email=/email_validation/;
var regex_username=/username_validation/;
$form.validation({
	custom:{
		login:function($el){
			var value=$el.val();
			//if not contains '@' we validate as username instead of email, and send a custom message
			if(~value.indexOf('@')) return regex_email.test(value);//only validation, show default message.
			else return {valid:regex_username.test(value),message:'Invalid username.'};//object with validation and custom message.
		}
	},
	errors:{
		login:'Invalid Email.'
	}
});
```