### PR TITLE
Reset functionality

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -50,6 +50,7 @@
 
     this.$element.on('input.bs.validator change.bs.validator focusout.bs.validator', $.proxy(this.onInput, this))
     this.$element.on('submit.bs.validator', $.proxy(this.onSubmit, this))
+    this.$element.on('reset.bs.validator', $.proxy(this.onReset, this))
 
     this.$element.find('[data-match]').each(function () {
       var $this  = $(this)
@@ -68,7 +69,7 @@
 
   Validator.VERSION = '0.11.0'
 
-  Validator.INPUT_SELECTOR = ':input:not([type="hidden"], [type="submit"], button)'
+  Validator.INPUT_SELECTOR = ':input:not([type="hidden"], [type="submit"], [type="reset"], button)'
 
   Validator.FOCUS_OFFSET = 20
 
@@ -228,6 +229,18 @@
     return this
   }
 
+  Validator.prototype.reset = function () {
+    var self = this
+
+    $.when(this.$inputs.map(function (el) {
+      return self.clearErrors($(this))
+    })).then(function () {
+      self.toggleSubmit()
+    })
+
+    return this
+  }
+
   Validator.prototype.focusError = function () {
     if (!this.options.focus) return
 
@@ -267,10 +280,11 @@
     var $feedback = $group.find('.form-control-feedback')
 
     $block.html($block.data('bs.validator.originalContent'))
-    $group.removeClass('has-error has-danger')
+    $group.removeClass('has-error has-success has-danger')
 
     $group.hasClass('has-feedback')
       && $feedback.removeClass(this.options.feedback.error)
+      && $feedback.removeClass(this.options.feedback.success)
       && getValue($el)
       && $feedback.addClass(this.options.feedback.success)
       && $group.addClass('has-success')
@@ -296,6 +310,10 @@
   Validator.prototype.onSubmit = function (e) {
     this.validate()
     if (this.isIncomplete() || this.hasErrors()) e.preventDefault()
+  }
+
+  Validator.prototype.onReset = function (e) {
+    this.reset()
   }
 
   Validator.prototype.toggleSubmit = function () {

--- a/js/validator.js
+++ b/js/validator.js
@@ -232,11 +232,13 @@
   Validator.prototype.reset = function () {
     var self = this
 
-    $.when(this.$inputs.map(function (el) {
-      return self.clearErrors($(this))
-    })).then(function () {
-      self.toggleSubmit()
-    })
+    setTimeout(function(){
+      $.when(self.$inputs.map(function (el) {
+        return self.clearErrors($(this))
+      })).then(function () {
+        self.toggleSubmit()
+      })
+    }, 50)
 
     return this
   }
@@ -280,7 +282,7 @@
     var $feedback = $group.find('.form-control-feedback')
 
     $block.html($block.data('bs.validator.originalContent'))
-    $group.removeClass('has-error has-success has-danger')
+    $group.removeClass('has-error has-danger has-success')
 
     $group.hasClass('has-feedback')
       && $feedback.removeClass(this.options.feedback.error)
@@ -334,7 +336,7 @@
       .removeData('bs.validator')
       .off('.bs.validator')
       .find('.form-control-feedback')
-        .removeClass([this.options.feedback.error, this.options.feedback.success].join(' '))
+      .removeClass([this.options.feedback.error, this.options.feedback.success].join(' '))
 
     this.$inputs
       .off('.bs.validator')
@@ -356,7 +358,7 @@
 
     this.$element.find('input[type="submit"], button[type="submit"]').removeClass('disabled')
 
-    this.$element.find('.has-error, .has-danger').removeClass('has-error has-danger')
+    this.$element.find('.has-error, .has-danger, .has-success').removeClass('has-error has-danger has-success')
 
     return this
   }


### PR DESCRIPTION
Hi,

I am missing some kind of reset function, which would bring the form back to initial state.
The reason for this (at least for me) is, that after AJAX submitting form I call reset method, so required fields gets empty, but they are still green, as if they are valid.
I do not want to call validate, as they will become red (invalid), which would be for user confusing, as he just fill it and submit it.

Also, in traditional approach with reset button, after clicking the reset button errors and success remains and submit button is still enabled.

Please consider this PR. It changes following
- reset input is removed from explicit validation (same as submit button)
- adds .validator('reset') function
- hooks reset event of the form, calling reset function
- on destroy it removes also has-success classes

Pavel

PS: there is setTimeout function, as I do not know better way how to hook after reset event.