### PR TITLE
Add 'bootstrap' in bower.json dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "*.html"
   ],
   "dependencies": {
+    "bootstrap": "^3.3.0",
     "jquery": ">= 1.8.3"
   }
 }


### PR DESCRIPTION
Bootstrap 3 is missing as dependency.

And, as this not officially supporting `v4-alpha`, I'm using `^3.3.0` constraint. This can be override per project, if needed, by [marking a resolution](https://github.com/bower/spec/blob/master/json.md#resolutions) in `bower.json` if is using Bootstrap 4.
