### PR TITLE
Added validator('reset') to index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -315,6 +315,9 @@ custom: {
     <h4><code>.validator('destroy')</code></h4>
     <p>Destroys form validator and cleans up data left behind.</p>
 
+    <h4><code>.validator('reset')</code></h4>
+    <p>Resets form validator back to initial state.</p>
+
     <h3 id="validator-events">Events</h3>
     <p>All events are fired on the form element and provide a reference to the form field to which the event pertains via <code>event.relatedTarget</code>.</p>
 


### PR DESCRIPTION
This is missing from documentation:

`$(...).validator('reset')` 

I found this feature from searching PRs. This will be helpful for people using this library.