### PR TITLE
Allow preventing auto validation for fields with values

### DIFF
--- a/js/tests/unit/validator.js
+++ b/js/tests/unit/validator.js
@@ -655,4 +655,20 @@ $(function () {
       done()
     }, 0)
   })
+
+  QUnit.test('should not clear help-blocks if auto is disabled', function (assert) {
+      var done = assert.async();
+      var form = '<form>'
+        + '<div class="form-group has-error">'
+        + '<input type="text" value="some value" required>'
+        + '<div id="errors" class="help-block with-errors></div>'
+        + '</div>'
+        + '</form>'
+
+      $(form).validator({auto: false})
+
+      assert.ok($(form).find('.form-group').hasClass('has-error'), '.has-error class not removed from form-group')
+      done();
+  })
+
 })

--- a/js/validator.js
+++ b/js/validator.js
@@ -61,7 +61,9 @@
       })
     })
 
-    this.$inputs.filter(function () { return getValue($(this)) }).trigger('focusout')
+    if (this.options.auto) {
+      this.$inputs.filter(function () { return getValue($(this)) }).trigger('focusout')
+    }
 
     this.$element.attr('novalidate', true) // disable automatic native validation
     this.toggleSubmit()
@@ -78,6 +80,7 @@
     html: false,
     disable: true,
     focus: true,
+    auto: true,
     custom: {},
     errors: {
       match: 'Does not match',


### PR DESCRIPTION
Hello,

This PR is a possible solution for #401.  The new option `auto`, which defaults to true, can be set to false to disable immediate validation of fields with values upon initialization of the validator (pre 0.11.0 behavior)

This option is useful if you are rendering server side errors and flashing old input to the form, as outlined in #401.

Let me know if anything needs improvement, and it won't hurt my feelings if this isn't something you want to merge 😄 

Thanks!
