### PR TITLE
fixing options persistence at new calls, and removing required dependency

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -377,11 +377,14 @@
   function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
-      var options = $.extend({}, Validator.DEFAULTS, $this.data(), typeof option == 'object' && option)
+      var dataOptions = $this.data() && $this.data()["bs.validator"] && $this.data()["bs.validator"].options
+                          ? $this.data()["bs.validator"].options : {};
+
+      var options = $.extend({}, Validator.DEFAULTS, $this.data(), dataOptions, typeof option == 'object' && option)
       var data    = $this.data('bs.validator')
 
       if (!data && option == 'destroy') return
-      if (!data) $this.data('bs.validator', (data = new Validator(this, options)))
+      $this.data('bs.validator', (data = new Validator(this, options)))
       if (typeof option == 'string') data[option]()
     })
   }

--- a/js/validator.js
+++ b/js/validator.js
@@ -203,8 +203,9 @@
 
     $.each(this.validators, $.proxy(function (key, validator) {
       var error = null
-      if ((getValue($el) || $el.attr('required')) &&
-          ($el.attr('data-' + key) !== undefined || key == 'native') &&
+      if (((getValue($el) || $el.attr('required')) &&
+          ($el.attr('data-' + key) !== undefined || key == 'native') ||
+         $el.data(key) && key != 'native' && key != 'required') &&
           (error = validator.call(this, $el))) {
          error = getErrorMessage(key) || error
         !~errors.indexOf(error) && errors.push(error)


### PR DESCRIPTION
the problem was that options were not been saved, because at merge of options (default, current, new) the current options were not considered as were lost on the process, "$this.data()" didn't work at least for this purpose.

the second problem was that the constructor of new validator was depend of "if(!data)" that was only true on the first call, what caused to call with new options were never saved at data.

/*-------------------------------------------------------------*/

remove dependency on required

remove dependency on required so multiple input custom validations don't have double message

example:

Input telephone and mobilephone either one of the is required but not both.
In the case of fill only one filed, the other would get required validator error.