### PR TITLE
Element must be visible, or offset() will bring user to top of screen.

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -240,7 +240,7 @@
   Validator.prototype.focusError = function () {
     if (!this.options.focus) return
 
-    var $input = this.$element.find(".has-error :input:first")
+    var $input = this.$element.find(".has-error :input:visible:first")
     if ($input.length === 0) return
 
     $('html, body').animate({scrollTop: $input.offset().top - Validator.FOCUS_OFFSET}, 250)


### PR DESCRIPTION
In case element is not visible offset() will return `top:0, left:0`

Use case: `<input type="radio" required>` where the first radio-item is
"hidden" in a collapsable div.

If you don't like this change, I can make a feature like
`$.fn.validator.Constructor.INPUT_SELECTOR`, but then for focusError.