### PR TITLE
Add errorschanged event trigger in showErrors / clearErrors

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -268,6 +268,8 @@
       && $feedback.removeClass(this.options.feedback.success)
       && $feedback.addClass(this.options.feedback.error)
       && $group.removeClass('has-success')
+      
+      this.$element.trigger($.Event('errorschanged.bs.validator', {relatedTarget: $el[0]}))
   }
 
   Validator.prototype.clearErrors = function ($el) {
@@ -284,6 +286,8 @@
       && getValue($el)
       && $feedback.addClass(this.options.feedback.success)
       && $group.addClass('has-success')
+      
+      this.$element.trigger($.Event('errorschanged.bs.validator', {relatedTarget: $el[0]}))
   }
 
   Validator.prototype.hasErrors = function () {


### PR DESCRIPTION
The existing events are triggered before the error content is added to the DOM if the "add error" operation is deferred.

This change provides a way to detect once the error information has been added.

In my case, this allowed me to display error information outside of the `form-group`, by hiding the `.help-block.with-errors` within the `form-group` and keeping its contents synced with an external element.