### PR TITLE
Updated runValidators function

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -203,7 +203,7 @@
 
     $.each(this.validators, $.proxy(function (key, validator) {
       var error = null
-      if ((getValue($el) || $el.attr('required')) &&
+      if ((getValue($el) || $el.attr('required') || $el.data('is-custom')) &&
           ($el.attr('data-' + key) !== undefined || key == 'native') &&
           (error = validator.call(this, $el))) {
          error = getErrorMessage(key) || error


### PR DESCRIPTION
Added a check for an "is-custom" parameter to bypass validation checks on the field itself, within the runValidators function, in case we need it for an advanced custom rule.
Changes were made so that we can have a solution for the following scenario: there are two fields, f1 that doesn't have a required parameter and f2 and we want to show an error under f1 if neither fields are valid from the app logic perspective.