### PR TITLE
Errors null bug

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -254,7 +254,7 @@
     var $block = $group.find('.help-block.with-errors')
     var $feedback = $group.find('.form-control-feedback')
 
-    if (!errors.length) return
+    if (errors) if (!errors.length) return
 
     errors = $('<ul/>')
       .addClass('list-unstyled')


### PR DESCRIPTION
When errors is null errors.length call is causing uncaught error. Fixed by adding check on errors and then calling the original errors.length.